### PR TITLE
Refine use of CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
-project(Buran)
+project(Buran VERSION 1.0.0)
+configure_file(
+    "buran_config.h.in"
+    "buran_config.h"
+)
 add_subdirectory(harbour-starship)
+

--- a/buran_config.h.in
+++ b/buran_config.h.in
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2022 - Ed Beroset <beroset@ieee.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#define VERSION "${Buran_VERSION_MAJOR}.${Buran_VERSION_MINOR}"
+
+#endif // CONFIG_H

--- a/harbour-starship/CMakeLists.txt
+++ b/harbour-starship/CMakeLists.txt
@@ -8,8 +8,6 @@ target_link_libraries(harbour-starship PRIVATE Qt5::Quick Qt5::Qml)
 target_include_directories(harbour-starship
     PUBLIC
         $<INSTALL_INTERFACE:.>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/services
+        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
 )
 install(TARGETS harbour-starship)

--- a/harbour-starship/src/harbour-starship.cpp
+++ b/harbour-starship/src/harbour-starship.cpp
@@ -17,6 +17,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "buran_config.h"
+
 #ifdef QT_QML_DEBUG
 #include <QtQuick>
 #endif
@@ -39,7 +41,7 @@ int main(int argc, char *argv[])
 
     QGuiApplication app(argc, argv);
 
-//    app->setApplicationVersion(VERSION);
+    app.setApplicationVersion(VERSION);
 //    QCoreApplication::setOrganizationName("harbour-starship");
 //    QCoreApplication::setOrganizationDomain("asteriodos.org");
 //    QCoreApplication::setApplicationName("harbour-starship");

--- a/starship.pro
+++ b/starship.pro
@@ -1,9 +1,0 @@
-TEMPLATE = subdirs
-QT += qml quick
-
-CONFIG += starship
-
-SUBDIRS = harbour-starship 
-include(version.pri)
-
-DISTFILES += \

--- a/version.pri
+++ b/version.pri
@@ -1,4 +1,0 @@
-VERSION = "1.0"
-DEFINES += VERSION=\\\"$$VERSION\\\"
-CONFIG += starship
-#DEFINES += 


### PR DESCRIPTION
This adds a configuration include file with the VERSION, uses that to
set the version of the application and removes some of the qmake files
that are no longer needed.

Signed-off-by: Ed Beroset <beroset@ieee.org>