### PR TITLE
Fix time setting from computer

### DIFF
--- a/harbour-starship/qml/pages/MainMenuPage.qml
+++ b/harbour-starship/qml/pages/MainMenuPage.qml
@@ -31,7 +31,10 @@ Pane {
     property int batteryLevel: root.watch.batteryLevel
     property int columns
 
-
+    Item {
+        id: settings
+        property bool timeSync : false
+    }
 
     //allowedOrientations: Orientation.All
     /*header: ToolBar {
@@ -112,7 +115,7 @@ Pane {
 
                 onPressed: {
                     toggled = !toggled
-                    //settings.timeSync = toggled
+                    settings.timeSync = toggled
                     if(settings.timeSync == true) timeSync();
 
                 }


### PR DESCRIPTION
The "enable time synchronisation" button now works and sets the time and
date on the selected watch.