### PR TITLE
Move dependency to top level CMake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(Buran VERSION 1.0.0)
+find_package(Qt5 COMPONENTS Qml Quick LinguistTools REQUIRED)
 configure_file(
     "buran_config.h.in"
     "buran_config.h"
 )
 add_subdirectory(src)
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.15)
-find_package(Qt5 COMPONENTS Qml Quick LinguistTools REQUIRED)
 set(xlatFiles 
     translations/qml_en.ts 
     translations/qml_de.ts
@@ -50,4 +49,4 @@ target_include_directories(buran
         $<INSTALL_INTERFACE:.>
         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
 )
-install(TARGETS buran CONFIGURATIONS Release)
+install(TARGETS buran)


### PR DESCRIPTION
This allows others to more quickly understand the dependencies of this
project.