### PR TITLE
Add asteroidsyncservice to build and install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ include(FetchContent)
 FetchContent_Declare(
   asteroidsyncservice
   GIT_REPOSITORY  https://github.com/AsteroidOS/asteroidsyncservice
-  GIT_TAG         8bfd1992242e305b580452eb928d8757ae6bd559
+  GIT_TAG         a7993d1b9bf1bafe91c7af949e13b9e7a5951bcd
 )
 set(DESKTOP_PLATFORM ON)
 FetchContent_MakeAvailable(asteroidsyncservice)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,13 @@
 cmake_minimum_required(VERSION 3.15)
 project(Buran VERSION 1.0.0)
+include(FetchContent)
+FetchContent_Declare(
+  asteroidsyncservice
+  GIT_REPOSITORY  https://github.com/AsteroidOS/asteroidsyncservice
+  GIT_TAG         8bfd1992242e305b580452eb928d8757ae6bd559
+)
+set(DESKTOP_PLATFORM ON)
+FetchContent_MakeAvailable(asteroidsyncservice)
 find_package(Qt5 COMPONENTS Qml Quick LinguistTools REQUIRED)
 configure_file(
     "buran_config.h.in"

--- a/src/qml/pages/MainMenuPage.qml
+++ b/src/qml/pages/MainMenuPage.qml
@@ -86,7 +86,7 @@ Pane {
                     enabled: watch && watch.screenshotServiceReady
                     width: parent.width/layout.columns
                     onClicked: {
-                        watch.sendNotify(Qt.formatDateTime(new Date(), "zzz"), qsTr("Telescope"), "ios-watch-vibrating", qsTr("Watch-Finder"), localHostName + qsTr(" is looking for you!"))
+                        watch.sendNotify(Qt.formatDateTime(new Date(), "zzz"), qsTr("Telescope"), "ios-watch-vibrating", qsTr("Watch-Finder"), localHostName + qsTr(" is looking for you!"), "strong")
                     }
                     imageSource: Qt.resolvedUrl("../img/ios-watch-vibrating.svg")
                     text: qsTr("Find my watch!")


### PR DESCRIPTION
This uses FetchContent rather than making asteroidsyncservice a
subproject to keep the CMake namespaces separate.