### PR TITLE
Correct the background image url to always load

### DIFF
--- a/src/qml/pages/RootUIDesktop.qml
+++ b/src/qml/pages/RootUIDesktop.qml
@@ -150,7 +150,7 @@ Page {
             clip: true
             Image {
                 anchors.fill: parent
-                source: "../img/background-default.jpg"
+                source: Qt.resolvedUrl("../img/background-default.jpg")
                 fillMode: Image.PreserveAspectCrop
                 mipmap: true
             }

--- a/src/qml/pages/RootUIMobile.qml
+++ b/src/qml/pages/RootUIMobile.qml
@@ -93,7 +93,7 @@ Page {
         Component.onCompleted: loadStack()
         Image {
             anchors.fill: parent
-            source: "../img/background-default.jpg"
+            source: Qt.resolvedUrl("../img/background-default.jpg")
             fillMode: Image.PreserveAspectCrop
             mipmap: true
         }


### PR DESCRIPTION
This fixes a subtle error in that the background image file, although it was included in the .qrc file, was not being referenced properly.  This makes sure that it always gets the image, whether or not it's a debug build or a release build.

Signed-off-by: Ed Beroset <beroset@ieee.org>