### PR TITLE
Fix image location for qrc file

### DIFF
--- a/src/buran.qrc
+++ b/src/buran.qrc
@@ -23,7 +23,7 @@
     <file>qml/img/md-watch.svg</file>
     <file>qml/img/md-settings.svg</file>
     <file>qml/img/time-sync.svg</file>
-    <file>qml/img/harbour-starship.svg</file>
+    <file>qml/img/buran.svg</file>
     <!-- components -->
     <file>qml/components/IconButton.qml</file>
     <!-- background -->


### PR DESCRIPTION
The qrc file still had harbour-starship.svg but the correct image is now buran.svg.  This fixes that error and now allows for a clean build in Release mode.